### PR TITLE
Add PASS 2023 Banner

### DIFF
--- a/docs/_includes/nav.html
+++ b/docs/_includes/nav.html
@@ -49,4 +49,5 @@
     </div>
   {% endif %}
 
+  {% include pass-banner.html %}
 </nav>

--- a/docs/_includes/pass-banner.html
+++ b/docs/_includes/pass-banner.html
@@ -1,0 +1,13 @@
+<div class="break"></div>
+<div class="summit-banner">
+    <ul class="list--horizontal">
+      <a href="https://passdatacommunitysummit.com/?utm_source=sqlservercentral&amp;utm_medium=display&amp;utm_campaign=summit&amp;utm_term=herobanner&amp;_gl=1*e1p04p*_ga*MTg5Mjc3ODMzNy4xNjk3NTU5Nzc4*_ga_X7VDRWRT4P*MTY5NzU1OTc3Ny4xLjAuMTY5NzU1OTc3Ny42MC4wLjA." target="_blank" rel="noopener noreferrer">
+        <li>
+          <img class="pass-logo-secondary-nav" src="https://www.sqlservercentral.com/wp-content/themes/ssc-twentyeighteen/images/nav-secondary/pass-2023.svg" alt="PASS logo" width="110" height="27">
+        </li>
+        <li class="text--bold">PASS Data Community Summit&nbsp;-&nbsp;<p></p> </li><li class="hide-on-small">In person. In Seattle | 14-17 November</li>
+        
+        <li class="text--bold find-out-more">Find out more <img src="https://www.sqlservercentral.com/wp-content/themes/ssc-twentyeighteen/images/nav-secondary/pass-arrow-right-ssc.svg"></li>
+      </a>
+    </ul>
+</div>

--- a/docs/assets/css/beautifuljekyll.css
+++ b/docs/assets/css/beautifuljekyll.css
@@ -3,6 +3,7 @@ layout: null
 ---
 
 @import url("pygment_highlights.css");
+@import url("pass-banner.css");
 
 /* --- General --- */
 

--- a/docs/assets/css/pass-banner.css
+++ b/docs/assets/css/pass-banner.css
@@ -1,0 +1,87 @@
+@import url('https://fonts.googleapis.com/css2?family=IBM+Plex+Sans+Condensed&display=swap');
+
+.summit-banner {
+    line-height: 50px;
+    font-size: 16px;
+    background-color: #EAEAEA;
+    border-top: 1px solid #DDDDDD;
+    text-decoration: none;
+    font-family: "IBM Plex Sans", "Helvetica Neue", Arial, Sans-serif !important;
+    width: 100%;
+    height: 50px;
+}
+
+.summit-banner a {
+    text-decoration: none;
+    color: #373737;
+}
+
+.summit-banner a:hover {
+    text-decoration: none;
+    color: #373737;
+}
+
+.summit-banner .text--bold {
+    font-weight: bold;
+}
+
+.find-out-more {
+    color: #183559;
+    margin-left:10px;
+}
+
+img.pass-logo-secondary-nav {
+    width: 100px;
+    margin-right: 10px;
+    margin-left:20px
+}
+
+.find-out-more img {
+    width: 18px;
+    height: 18px;
+    margin: 0px 10px 0px 5px;
+}
+
+.list--horizontal {
+  margin-left: 0px;
+  list-style: none;
+  padding-left: 0px;
+}
+
+.list--horizontal li {
+  display: inline-block;
+}
+
+.break {
+    flex-basis: 100%;
+    height: 0;
+}
+
+/* Add flex-wrap to the navbar so banner can be forced onto new row */
+.navbar {
+    flex-wrap: wrap;
+}
+
+.navbar-custom {
+    padding-bottom: 0px!important;
+}
+
+@media (max-width: 1200px) {
+    .intro-header {
+        margin-top: 110px!important;
+    }
+}
+
+@media (max-width: 700px) {
+    .hide-on-small {
+        display: none!important;
+    }
+
+    .img.pass-logo-secondary-nav {
+        margin-left: 0px;
+    }
+
+    .find-out-more {
+        margin-left:0px;
+    }
+}


### PR DESCRIPTION
Per Carly's request here: https://redgate.monday.com/boards/3660152925/pulses/5224253569, adding a banner to SQLSaturday.com. This adds quite a lot of styles in order to get the banner to work correctly with the nav animation, so I've hived them off into their own stylesheet, and I'll add a reversion PR to take all of this down once we're ready.

In case people don't want to build locally, this is the design:

**Fullscreen:** 
![image](https://github.com/red-gate/sql-saturday-website/assets/1324433/fb468c95-0869-4d2e-b235-8671462aafe3)

**Mobile:**
![image](https://github.com/red-gate/sql-saturday-website/assets/1324433/d6186901-c20a-4653-91f4-5f063fcb5b04)

